### PR TITLE
fix: prevent TypeScript warning in production

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -1,5 +1,9 @@
 #!/usr/bin/env node
 
-import {execute} from '@oclif/core'
+import { execute } from "@oclif/core";
 
-await execute({dir: import.meta.url})
+await execute({
+	// Explicitly set production mode to avoid TypeScript checks
+	development: false,
+	dir: import.meta.url,
+});


### PR DESCRIPTION
## Description
This PR fixes the TypeScript warning that users see when running the published package.

## Problem
When users run `chi` from the globally installed package or via npx, they may see:
```
Warning: Could not find typescript. Please ensure that typescript is a devDependency.
```

## Solution
Set `development: false` in the execute() call in bin/run.js. This prevents oclif from performing TypeScript checks in production environments.

## Testing
- This approach is proven to work in the claude-hooks project
- The `development: false` flag tells oclif to skip development-specific checks
- This doesn't affect development mode since bin/dev.js is used for development

## Changes
- Added `development: false` to the execute() call in bin/run.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved formatting and clarity of the command execution logic.
  * Explicitly enforced production mode during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->