### PR TITLE
fix: prevent TypeScript warning using NODE_ENV environment variable

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -1,9 +1,8 @@
 #!/usr/bin/env node
 
+// Set production mode before importing to prevent TypeScript detection
+process.env.NODE_ENV = "production";
+
 import { execute } from "@oclif/core";
 
-await execute({
-	// Explicitly set production mode to avoid TypeScript checks
-	development: false,
-	dir: import.meta.url,
-});
+await execute({ dir: import.meta.url });


### PR DESCRIPTION
## Description
This PR fixes the TypeScript warning using the environment variable approach, which is more reliable than the development flag.

## Problem
When users run `chi` from the globally installed package or via npx, they see:
```
Warning: Could not find typescript. Please ensure that typescript is a devDependency.
```

## Root Cause
Oclif checks for TypeScript during module import, not during execution. It searches for tsconfig.json starting from the current working directory.

## Solution
Set `NODE_ENV=production` in bin/run.js BEFORE importing @oclif/core. This prevents the TypeScript detection check from running at import time.

## Why This Approach
- Setting `development: false` in execute() is too late - the check happens during import
- The NODE_ENV approach prevents the check at the correct time
- This approach has been proven to work reliably in other oclif projects

## Changes
- Added `process.env.NODE_ENV = 'production'` before the import statement in bin/run.js
- Removed the `development: false` flag from execute() as it's no longer needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved handling of production mode by setting the environment variable directly. No visible changes to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->